### PR TITLE
Added a VirtualBox derivation with support for headless builds

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -11,7 +11,8 @@ let
   inherit (pkgs)
     lib
     pythonPackages perlPackages haskellPackages
-    stdenv fetchurl;
+    stdenv_32bit gnome
+    stdenv fetchurl newScope;
   inherit (lib) overrideDerivation;
 
   fns = {
@@ -287,5 +288,10 @@ in rec {
     ];
 
     NIX_CFLAGS_COMPILE = "-I${imagemagick}/include/ImageMagick-6";
+  };
+
+  virtualbox = linuxPackages: (newScope linuxPackages) ./virtualbox {
+    stdenv = stdenv_32bit;
+    inherit (gnome) libIDL;
   };
 }

--- a/pkgs/virtualbox/default.nix
+++ b/pkgs/virtualbox/default.nix
@@ -1,0 +1,206 @@
+{ stdenv, fetchurl, lib, iasl, dev86, pam, libxslt, libxml2
+, libIDL, libcap, zlib, libpng, glib, kernel, lvm2
+, which, alsaLib, curl, libvpx, gawk, nettools
+, xorriso, makeself, perl, pkgconfig, nukeReferences
+, javaBindings ? false, jdk ? null
+, pythonBindings ? false, python ? null
+, enableExtensionPack ? false, requireFile ? null, patchelf ? null, fakeroot ? null
+, pulseSupport ? false, pulseaudio ? null
+, guiSupport ? true, xproto ? null, libX11 ? null, libXext ? null, libXcursor ? null, qt4 ? null, SDL ? null, libXmu ? null
+, enableHardening ? false
+}:
+
+with stdenv.lib;
+
+let
+  buildType = "release";
+
+  version = "4.3.20"; # changes ./guest-additions as well
+
+  forEachModule = action: ''
+    for mod in \
+      out/linux.*/${buildType}/bin/src/vboxdrv \
+      out/linux.*/${buildType}/bin/src/vboxpci \
+      out/linux.*/${buildType}/bin/src/vboxnetadp \
+      out/linux.*/${buildType}/bin/src/vboxnetflt
+    do
+      if [ "x$(basename "$mod")" != xvboxdrv -a ! -e "$mod/Module.symvers" ]
+      then
+        cp -v out/linux.*/${buildType}/bin/src/vboxdrv/Module.symvers \
+          "$mod/Module.symvers"
+      fi
+      INSTALL_MOD_PATH="$out" INSTALL_MOD_DIR=misc \
+      make -C "$MODULES_BUILD_DIR" DEPMOD=/do_not_use_depmod \
+        "M=\$(PWD)/$mod" BUILD_TYPE="${buildType}" ${action}
+    done
+  '';
+
+  # See https://github.com/NixOS/nixpkgs/issues/672 for details
+  extpackRevision = "96996";
+  extensionPack = requireFile rec {
+    name = "Oracle_VM_VirtualBox_Extension_Pack-${version}-${extpackRevision}.vbox-extpack";
+    # IMPORTANT: Hash must be base16 encoded because it's used as an input to
+    # VBoxExtPackHelperApp!
+    # Tip: see http://dlc.sun.com.edgesuite.net/virtualbox/4.3.10/SHA256SUMS
+    sha256 = "7e1253f7013e9cdc84a614a0db38b40de7bbd330cb5b85bd3ef3de213773450d";
+    message = ''
+      In order to use the extension pack, you need to comply with the VirtualBox Personal Use
+      and Evaluation License (PUEL) by downloading the related binaries from:
+
+      https://www.virtualbox.org/wiki/Downloads
+
+      Once you have downloaded the file, please use the following command and re-run the
+      installation:
+
+      nix-prefetch-url file://${name}
+    '';
+  };
+
+  graphicalInputs = [
+    xproto libX11 libXext libXcursor qt4
+    SDL libXmu
+  ];
+
+in stdenv.mkDerivation {
+  name = "virtualbox-${version}-${kernel.version}";
+
+  src = fetchurl {
+    url = "http://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}.tar.bz2";
+    sha256 = "1484f8e9993ec4fe3892c5165db84d238713d2506e147ed8236541ece642e965";
+  };
+
+  buildInputs =
+    [ iasl dev86 libxslt libxml2 libIDL
+      libcap glib lvm2 python alsaLib curl
+      libvpx pam xorriso makeself perl
+      pkgconfig which nukeReferences libpng ]
+    ++ optional javaBindings jdk
+    ++ optional pythonBindings python
+    ++ optional pulseSupport pulseaudio
+    ++ optionals guiSupport graphicalInputs;
+
+  prePatch = ''
+    set -x
+    MODULES_BUILD_DIR=`echo ${kernel.dev}/lib/modules/*/build`
+    sed -e 's@/lib/modules/`uname -r`/build@'$MODULES_BUILD_DIR@ \
+        -e 's@MKISOFS --version@MKISOFS -version@' \
+        -e 's@PYTHONDIR=.*@PYTHONDIR=${if pythonBindings then python else ""}@' \
+        -i configure
+    ls kBuild/bin/linux.x86/k* tools/linux.x86/bin/* | xargs -n 1 patchelf --set-interpreter ${stdenv.glibc}/lib/ld-linux.so.2
+    ls kBuild/bin/linux.amd64/k* tools/linux.amd64/bin/* | xargs -n 1 patchelf --set-interpreter ${stdenv.glibc}/lib/ld-linux-x86-64.so.2
+    find . -type f -iname '*makefile*' -exec sed -i -e 's/depmod -a/:/g' {} +
+    sed -e 's@"libasound.so.2"@"${alsaLib}/lib/libasound.so.2"@g' -i src/VBox/Main/xml/Settings.cpp src/VBox/Devices/Audio/alsa_stubs.c
+    export USER=nix
+    set +x
+  '';
+
+  patches = optional enableHardening ./hardened.patch;
+
+  postPatch = ''
+    sed -i -e 's|/sbin/ifconfig|${nettools}/bin/ifconfig|' \
+      src/apps/adpctl/VBoxNetAdpCtl.cpp
+  '';
+
+  configurePhase = ''
+    cat >> LocalConfig.kmk <<LOCAL_CONFIG
+    VBOX_WITH_TESTCASES            :=
+    VBOX_WITH_TESTSUITE            :=
+    VBOX_WITH_VALIDATIONKIT        :=
+    VBOX_WITH_DOCS                 :=
+    VBOX_WITH_WARNINGS_AS_ERRORS   :=
+
+    VBOX_WITH_ORIGIN               :=
+    VBOX_PATH_APP_PRIVATE_ARCH_TOP := $out/share/virtualbox
+    VBOX_PATH_APP_PRIVATE_ARCH     := $out/libexec/virtualbox
+    VBOX_PATH_SHARED_LIBS          := $out/libexec/virtualbox
+    VBOX_WITH_RUNPATH              := $out/libexec/virtualbox
+    VBOX_PATH_APP_PRIVATE          := $out/share/virtualbox
+    VBOX_PATH_APP_DOCS             := $out/doc
+    ${optionalString (!guiSupport) ''
+    VBOX_HEADLESS                  := 1
+    VBOX_WITHOUT_ADDITIONS         := 1
+    ''}
+    ${optionalString javaBindings ''
+    VBOX_JAVA_HOME                 := ${jdk}
+    ''}
+    LOCAL_CONFIG
+
+    ./configure \
+      ${optionalString (guiSupport) "--with-qt4-dir=${qt4}"} \
+      ${optionalString (!javaBindings) "--disable-java"} \
+      ${optionalString (!pythonBindings) "--disable-python"} \
+      ${optionalString (!pulseSupport) "--disable-pulse"} \
+      ${optionalString (!enableHardening) "--disable-hardening"} \
+      ${optionalString (!guiSupport) "--build-headless"} \
+      --disable-kmods --with-mkisofs=${xorriso}/bin/xorrisofs
+    sed -e 's@PKG_CONFIG_PATH=.*@PKG_CONFIG_PATH=${libIDL}/lib/pkgconfig:${glib}/lib/pkgconfig ${libIDL}/bin/libIDL-config-2@' \
+        -i AutoConfig.kmk
+    sed -e 's@arch/x86/@@' \
+        -i Config.kmk
+    substituteInPlace Config.kmk --replace "VBOX_WITH_TESTCASES = 1" "#"
+  '';
+
+  enableParallelBuilding = true;
+
+  buildPhase = ''
+    source env.sh
+    kmk BUILD_TYPE="${buildType}"
+    ${forEachModule "modules"}
+  '';
+
+  installPhase = ''
+    libexec="$out/libexec/virtualbox"
+    share="${if enableHardening then "$out/share/virtualbox" else "$libexec"}"
+
+    # Install VirtualBox files
+    mkdir -p "$libexec"
+    find out/linux.*/${buildType}/bin -mindepth 1 -maxdepth 1 \
+      -name src -o -exec cp -avt "$libexec" {} +
+
+    # Install kernel modules
+    ${forEachModule "modules_install"}
+
+    # Create wrapper script
+    mkdir -p $out/bin
+    for file in VirtualBox VBoxManage VBoxSDL VBoxBalloonCtrl VBoxBFE VBoxHeadless; do
+        ln -s "$libexec/$file" $out/bin/$file
+    done
+
+    ${optionalString enableExtensionPack ''
+      mkdir -p "$share"
+      "${fakeroot}/bin/fakeroot" "${stdenv.shell}" <<EXTHELPER
+      "$libexec/VBoxExtPackHelperApp" install \
+        --base-dir "$share/ExtensionPacks" \
+        --cert-dir "$share/ExtPackCertificates" \
+        --name "Oracle VM VirtualBox Extension Pack" \
+        --tarball "${extensionPack}" \
+        --sha-256 "${extensionPack.outputHash}"
+      EXTHELPER
+    ''}
+
+    ${optionalString guiSupport ''
+      # Create and fix desktop item
+      mkdir -p $out/share/applications
+      sed -i -e "s|Icon=VBox|Icon=$libexec/VBox.png|" $libexec/virtualbox.desktop
+      ln -sfv $libexec/virtualbox.desktop $out/share/applications
+      # Icons
+      mkdir -p $out/share/icons/hicolor
+      for size in `ls -1 $libexec/icons`; do
+        mkdir -p $out/share/icons/hicolor/$size/apps
+        ln -s $libexec/icons/$size/*.png $out/share/icons/hicolor/$size/apps
+      done
+    ''}
+
+    # Get rid of a reference to linux.dev.
+    nuke-refs $out/lib/modules/*/misc/*.ko
+  '';
+
+  passthru = { inherit version; /* for guest additions */ };
+
+  meta = {
+    description = "PC emulator";
+    homepage = http://www.virtualbox.org/;
+    maintainers = [ lib.maintainers.sander ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/virtualbox/hardened.patch
+++ b/pkgs/virtualbox/hardened.patch
@@ -1,0 +1,207 @@
+diff --git a/include/iprt/mangling.h b/include/iprt/mangling.h
+index 70c596a..78972ed 100644
+--- a/include/iprt/mangling.h
++++ b/include/iprt/mangling.h
+@@ -1068,6 +1068,7 @@
+ # define RTPathStripSuffix                              RT_MANGLER(RTPathStripSuffix)
+ # define RTPathStripFilename                            RT_MANGLER(RTPathStripFilename)
+ # define RTPathStripTrailingSlash                       RT_MANGLER(RTPathStripTrailingSlash)
++# define RTPathSuidDir                                  RT_MANGLER(RTPathSuidDir)
+ # define RTPathTemp                                     RT_MANGLER(RTPathTemp)
+ # define RTPathTraverseList                             RT_MANGLER(RTPathTraverseList)
+ # define RTPathUnlink                                   RT_MANGLER(RTPathUnlink)
+@@ -1105,6 +1106,7 @@
+ # define RTProcGetAffinityMask                          RT_MANGLER(RTProcGetAffinityMask)
+ # define RTProcGetExecutablePath                        RT_MANGLER(RTProcGetExecutablePath)
+ # define RTProcGetPriority                              RT_MANGLER(RTProcGetPriority)
++# define RTProcGetSuidPath                              RT_MANGLER(RTProcGetSuidPath)
+ # define RTProcIsRunningByName                          RT_MANGLER(RTProcIsRunningByName)
+ # define RTProcQueryParent                              RT_MANGLER(RTProcQueryParent)
+ # define RTProcQueryUsername                            RT_MANGLER(RTProcQueryUsername)
+diff --git a/include/iprt/path.h b/include/iprt/path.h
+index 7e42754..b4de4c8 100644
+--- a/include/iprt/path.h
++++ b/include/iprt/path.h
+@@ -1049,6 +1049,15 @@ RTDECL(int) RTPathCalcRelative(char *pszPathDst, size_t cbPathDst,
+ RTDECL(int) RTPathExecDir(char *pszPath, size_t cchPath);
+ 
+ /**
++ * Gets the path to the NixOS setuid wrappers directory.
++ *
++ * @returns iprt status code.
++ * @param   pszPath     Buffer where to store the path.
++ * @param   cchPath     Buffer size in bytes.
++ */
++RTDECL(int) RTPathSuidDir(char *pszPath, size_t cchPath);
++
++/**
+  * Gets the user home directory.
+  *
+  * @returns iprt status code.
+diff --git a/include/iprt/process.h b/include/iprt/process.h
+index 2760306..0ce6c92 100644
+--- a/include/iprt/process.h
++++ b/include/iprt/process.h
+@@ -313,6 +313,16 @@ RTR3DECL(const char *) RTProcShortName(void);
+ RTR3DECL(char *) RTProcGetExecutablePath(char *pszExecPath, size_t cbExecPath);
+ 
+ /**
++ * Gets the path to the NixOS setuid wrappers directory.
++ *
++ * @returns pszExecPath on success. NULL on buffer overflow or other errors.
++ *
++ * @param   pszExecPath     Where to store the path.
++ * @param   cbExecPath      The size of the buffer.
++ */
++RTR3DECL(char *) RTProcGetSuidPath(char *pszExecPath, size_t cbExecPath);
++
++/**
+  * Daemonize the current process, making it a background process.
+  *
+  * The way this work is that it will spawn a detached / backgrounded /
+diff --git a/src/VBox/HostDrivers/Support/SUPR3HardenedVerify.cpp b/src/VBox/HostDrivers/Support/SUPR3HardenedVerify.cpp
+index c39d2f7..896b352 100644
+--- a/src/VBox/HostDrivers/Support/SUPR3HardenedVerify.cpp
++++ b/src/VBox/HostDrivers/Support/SUPR3HardenedVerify.cpp
+@@ -1415,18 +1415,19 @@ static int supR3HardenedVerifyFsObject(PCSUPR3HARDENEDFSOBJSTATE pFsObjState, bo
+         NOREF(fRelaxed);
+ #else
+         NOREF(fRelaxed);
+-        bool fBad = true;
++        bool fBad = !(fDir && pFsObjState->Stat.st_mode & S_ISVTX && !suplibHardenedStrCmp(pszPath, "/nix/store"));
+ #endif
+-        if (fBad)
++        if (fBad && suplibHardenedStrCmp(pszPath, "/nix/store"))
+             return supR3HardenedSetError3(VERR_SUPLIB_WRITE_NON_SYS_GROUP, pErrInfo,
+                                           "An unknown (and thus untrusted) group has write access to '", pszPath,
+                                           "' and we therefore cannot trust the directory content or that of any subdirectory");
+     }
+ 
+     /*
+-     * World must not have write access.  There is no relaxing this rule.
++     * World must not have write access.
++     * There is no relaxing this rule, except when it comes to the Nix store.
+      */
+-    if (pFsObjState->Stat.st_mode & S_IWOTH)
++    if (pFsObjState->Stat.st_mode & S_IWOTH && suplibHardenedStrCmp(pszPath, "/nix/store"))
+         return supR3HardenedSetError3(VERR_SUPLIB_WORLD_WRITABLE, pErrInfo,
+                                       "World writable: '", pszPath, "'");
+ 
+diff --git a/src/VBox/Main/src-server/MachineImpl.cpp b/src/VBox/Main/src-server/MachineImpl.cpp
+index 95dc9a7..39170bc 100644
+--- a/src/VBox/Main/src-server/MachineImpl.cpp
++++ b/src/VBox/Main/src-server/MachineImpl.cpp
+@@ -7326,7 +7326,7 @@ HRESULT Machine::i_launchVMProcess(IInternalSessionControl *aControl,
+ 
+     /* get the path to the executable */
+     char szPath[RTPATH_MAX];
+-    RTPathAppPrivateArch(szPath, sizeof(szPath) - 1);
++    RTStrCopy(szPath, sizeof(szPath) - 1, "/var/setuid-wrappers");
+     size_t cchBufLeft = strlen(szPath);
+     szPath[cchBufLeft++] = RTPATH_DELIMITER;
+     szPath[cchBufLeft] = 0;
+diff --git a/src/VBox/Main/src-server/NATNetworkServiceRunner.cpp b/src/VBox/Main/src-server/NATNetworkServiceRunner.cpp
+index 090018e..7dcfc7a 100644
+--- a/src/VBox/Main/src-server/NATNetworkServiceRunner.cpp
++++ b/src/VBox/Main/src-server/NATNetworkServiceRunner.cpp
+@@ -75,7 +75,7 @@ int NATNetworkServiceRunner::start()
+ 
+     /* get the path to the executable */
+     char exePathBuf[RTPATH_MAX];
+-    const char *exePath = RTProcGetExecutablePath(exePathBuf, RTPATH_MAX);
++    const char *exePath = RTProcGetSuidPath(exePathBuf, RTPATH_MAX);
+     char *substrSl = strrchr(exePathBuf, '/');
+     char *substrBs = strrchr(exePathBuf, '\\');
+     char *suffix = substrSl ? substrSl : substrBs;
+diff --git a/src/VBox/Main/src-server/NetworkServiceRunner.cpp b/src/VBox/Main/src-server/NetworkServiceRunner.cpp
+index e9e1ba62..4d1c1e1 100644
+--- a/src/VBox/Main/src-server/NetworkServiceRunner.cpp
++++ b/src/VBox/Main/src-server/NetworkServiceRunner.cpp
+@@ -79,7 +79,7 @@ int NetworkServiceRunner::start()
+ 
+     /* get the path to the executable */
+     char exePathBuf[RTPATH_MAX];
+-    const char *exePath = RTProcGetExecutablePath(exePathBuf, RTPATH_MAX);
++    const char *exePath = RTProcGetSuidPath(exePathBuf, RTPATH_MAX);
+     char *substrSl = strrchr(exePathBuf, '/');
+     char *substrBs = strrchr(exePathBuf, '\\');
+     char *suffix = substrSl ? substrSl : substrBs;
+diff --git a/src/VBox/Main/src-server/generic/NetIf-generic.cpp b/src/VBox/Main/src-server/generic/NetIf-generic.cpp
+index 8559d2a..2177f27 100644
+--- a/src/VBox/Main/src-server/generic/NetIf-generic.cpp
++++ b/src/VBox/Main/src-server/generic/NetIf-generic.cpp
+@@ -47,7 +47,7 @@ static int NetIfAdpCtl(const char * pcszIfName, const char *pszAddr, const char
+     const char *args[] = { NULL, pcszIfName, pszAddr, pszOption, pszMask, NULL };
+ 
+     char szAdpCtl[RTPATH_MAX];
+-    int rc = RTPathExecDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME));
++    int rc = RTPathSuidDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME));
+     if (RT_FAILURE(rc))
+     {
+         LogRel(("NetIfAdpCtl: failed to get program path, rc=%Rrc.\n", rc));
+@@ -90,7 +90,7 @@ static int NetIfAdpCtl(HostNetworkInterface * pIf, const char *pszAddr, const ch
+ int NetIfAdpCtlOut(const char * pcszName, const char * pcszCmd, char *pszBuffer, size_t cBufSize)
+ {
+     char szAdpCtl[RTPATH_MAX];
+-    int rc = RTPathExecDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME " ") - strlen(pcszCmd));
++    int rc = RTPathSuidDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME " ") - strlen(pcszCmd));
+     if (RT_FAILURE(rc))
+     {
+         LogRel(("NetIfAdpCtlOut: Failed to get program path, rc=%Rrc\n", rc));
+@@ -202,7 +202,7 @@ int NetIfCreateHostOnlyNetworkInterface(VirtualBox *pVirtualBox,
+             progress.queryInterfaceTo(aProgress);
+ 
+             char szAdpCtl[RTPATH_MAX];
+-            int rc = RTPathExecDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME " add"));
++            int rc = RTPathSuidDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME " add"));
+             if (RT_FAILURE(rc))
+             {
+                 progress->i_notifyComplete(E_FAIL,
+diff --git a/src/VBox/Runtime/r3/path.cpp b/src/VBox/Runtime/r3/path.cpp
+index be2ad8f..7ddf105 100644
+--- a/src/VBox/Runtime/r3/path.cpp
++++ b/src/VBox/Runtime/r3/path.cpp
+@@ -81,6 +81,12 @@ RTDECL(int) RTPathExecDir(char *pszPath, size_t cchPath)
+ }
+ 
+ 
++RTDECL(int) RTPathSuidDir(char *pszPath, size_t cchPath)
++{
++    return RTStrCopy(pszPath, cchPath, "/var/setuid-wrappers");
++}
++
++
+ RTDECL(int) RTPathAppPrivateNoArch(char *pszPath, size_t cchPath)
+ {
+ #if !defined(RT_OS_WINDOWS) && defined(RTPATH_APP_PRIVATE)
+diff --git a/src/VBox/Runtime/r3/process.cpp b/src/VBox/Runtime/r3/process.cpp
+index 7bde6af..2656cae 100644
+--- a/src/VBox/Runtime/r3/process.cpp
++++ b/src/VBox/Runtime/r3/process.cpp
+@@ -111,6 +111,26 @@ RTR3DECL(char *) RTProcGetExecutablePath(char *pszExecPath, size_t cbExecPath)
+     return NULL;
+ }
+ 
++/*
++ * Note the / at the end! This is important, because the functions using this
++ * will cut off everything after the rightmost / as this function is analogous
++ * to RTProcGetExecutablePath().
++ */
++#define SUIDDIR "/var/setuid-wrappers/"
++
++RTR3DECL(char *) RTProcGetSuidPath(char *pszExecPath, size_t cbExecPath)
++{
++    if (cbExecPath >= sizeof(SUIDDIR))
++    {
++        memcpy(pszExecPath, SUIDDIR, sizeof(SUIDDIR));
++        pszExecPath[sizeof(SUIDDIR)] = '\0';
++        return pszExecPath;
++    }
++
++    AssertMsgFailed(("Buffer too small (%zu <= %zu)\n", cbExecPath, sizeof(SUIDDIR)));
++    return NULL;
++}
++
+ 
+ RTR3DECL(const char *) RTProcShortName(void)
+ {


### PR DESCRIPTION
Parametrised with 'linuxPackages', as this is kernel-dependent. Override
with 'guiSupport = false' to omit graphical dependencies.

```
% nix-store -q --references result
/nix/store/r5sxfcwq9324xvcd1z312kb9kkddqvld-bash-4.3-p30
/nix/store/18kf2iwp45rlcv1a7y8mjmnv1n3kdwbs-lvm2-2.02.111
/nix/store/584hmj4dvlp9aj9n4kcc52a5wz1aq9ac-zlib-1.2.8
/nix/store/3j5wxgnqhkprdzmwwwprk60iyrbn89hf-glib-2.42.1
/nix/store/43z80v9fkdwglg0pwb5i8m9f2z493az1-libxml2-2.9.2
/nix/store/608381h0c3ilqfdajrfn0f5gwlr58pmc-alsa-lib-1.0.28
/nix/store/y7p2f732xrdpyzvxx574q7zr7yi2rs9y-openssl-1.0.1k
/nix/store/8mpzx29f2qwqlnahcsd6vr88ri421dx1-curl-7.39.0
/nix/store/ariw3zi38k76ar0vy26jdfk6p3y7pqcp-libvpx-1.3.0
/nix/store/dfl7l46npf64ym6ylz5lva4s8z20z284-glibc-multi-2.20
/nix/store/ch60971fb97srlw3hkwsmbash9pkdy17-gcc-4.8.3
/nix/store/lhahn4pa6xzchshjfjvl36ppc9ranhf6-libpng-1.6.16
/nix/store/qvhwld6fk4435q08rk7jbc2g69gshgwf-libIDL-0.8.14
/nix/store/xfzrzjb7p9i0nhnyqy18lz4bh01r6pnw-net-tools-1.60_p20120127084908
/nix/store/0yazlqv7pq1iphh0lzc6xa1wgalqa5p4-virtualbox-4.3.20-3.14.32
```
