### PR TITLE
retry: don't retry with stdin

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -148,8 +148,9 @@ in rec {
 
   get-user-data = pkgs.writeScriptBin "get-user-data" ''
     #! /bin/sh
-    exec ${retry}/bin/retry \
-      ${pkgs.curl}/bin/curl -sf http://169.254.169.254/latest/user-data
+    exec ${pkgs.wget}/bin/wget \
+      --retry-connrefused \
+      -q -O - http://169.254.169.254/latest/user-data
   '';
 
   go = pkgs.callPackage ./go/1.4.nix {};

--- a/pkgs/retry/retry
+++ b/pkgs/retry/retry
@@ -2,6 +2,10 @@
 #
 # usage: retry COMMAND [ARGS...]
 #
+# Retry to run a command successfully with configurable delays between runs.
+#
+# Notice that the command won't receive any data via standard input.
+#
 set -euf
 
 export PATH=@coreutils@/bin"${PATH+:$PATH}"
@@ -23,12 +27,6 @@ retry_delay_seq=${RETRY_DELAY_SEQ:-$(
   done
 )}
 
-# In order to retry stdin-reading commands, we have to cache and resupply it.
-#
-# Notice how this expects stdin to fit into memory.
-#
-stdin_cache=$(cat)
-
 # main COMMAND [ARGS...]
 main() {
   try_exec "$@"
@@ -46,7 +44,7 @@ main() {
 # process (mimicking the behavior of exec).  Otherwise set the exit_code
 # variable for further inspection (or retry in our case).
 try_exec() {
-  if echo "$stdin_cache" | env "$@"; then
+  if env "$@" </dev/null; then
     exit
   else
     exit_code=$?


### PR DESCRIPTION
The current implementation of `retry` subliminally advertises the capability of retrying any process, regardless if it consumes stdin or not.  This is not true, any program that doesn't consume stdin will hang in the `cat`. As it turns out, making `retry` work with both stdin-reading and not stdin-reading programs is complicated (see POC below) and as microgram doesn't need retrying with stdin, let's just drop support for it [and pretend it never existed ;)].
## 

POC: retry for both (Notice how command cannot write to stdout, this could be mitigated with more pipes...):

``` sh
#! /usr/bin/env bash
set -efu

com=retry.com
rm -f "$com"
trap 'rm -f "$com"' EXIT
mkfifo "$com"

export main_pid=${main_pid-$$}

retry_loop=${retry_loop-0}

tee >(set +e; "$@"; echo $? >"$com") | {
  exit_code=$(<"$com")
  case $exit_code in
    0)
      kill "$main_pid"
      ;;
    *)
      export retry_loop=$((retry_loop + 1))
      exec "$0" "$@"
      ;;
  esac
}
```
