### PR TITLE
Update README to drop ruby packaging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ upcast build-remote -t builder.example.com -A ebs-ami-builder tests/nginx.nix
 
 ### Packaging software
 
-* [to-nix/ruby](to-nix/ruby) - Ruby packaging documentation and tools
 * [to-nix/python](to-nix/python) - Python packaging documentation and tools (previously known as python2nix)
 * [to-nix/haskell](to-nix/haskell) - Haskell packaging documentation for programs using Cabal
 * [to-nix/golang](to-nix/golang) - Go packaging documentation for Nix


### PR DESCRIPTION
I was reading through docs, and this link 404s (looks like it was removed recently).
