### PR TITLE
upcast{,-ng}: use overrideDerivation

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -348,14 +348,14 @@ in rec {
 
   unicron = fns.staticHaskellCallPackage ./unicron {};
 
-  upcast = pkgs.haskell.lib.overrideCabal (fns.staticHaskellCallPackage ./upcast {
+  upcast = lib.overrideDerivation (fns.staticHaskellCallPackage ./upcast {
     inherit (amazonka_1_1_0) amazonka amazonka-core amazonka-ec2 amazonka-elb amazonka-route53;
   }) (drv: {
     postFixup = "rm -rf $out/lib $out/nix-support";
   });
 
   upcast-ng = let
-    ng = pkgs.haskell.lib.overrideCabal (fns.staticHaskellCallPackage ./upcast/ng.nix {
+    ng = lib.overrideDerivation (fns.staticHaskellCallPackage ./upcast/ng.nix {
       inherit amazonka amazonka-core amazonka-ec2 amazonka-elb amazonka-route53;
     }) (drv: {
       postFixup = "rm -rf $out/lib $out/nix-support";


### PR DESCRIPTION
This PR causes the `postFixup` overrides for `upcast` and `upcast-ng` to become effective. I'm not 100% certain this is the best way to do it, but the current use of `overrideCabal` doesn't do the right thing, which can be illustrated with following patch:

``` diff
diff --git a/pkgs/default.nix b/pkgs/default.nix
index 8151f18..23879d3 100644
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -348,11 +348,20 @@ in rec {

   unicron = fns.staticHaskellCallPackage ./unicron {};

-  upcast = pkgs.haskell.lib.overrideCabal (fns.staticHaskellCallPackage ./upcast {
-    inherit (amazonka_1_1_0) amazonka amazonka-core amazonka-ec2 amazonka-elb amazonka-route53;
-  }) (drv: {
-    postFixup = "rm -rf $out/lib $out/nix-support";
-  });
+  upcast = let
+    pkg0 = fns.staticHaskellCallPackage ./upcast {
+      inherit (amazonka_1_1_0) amazonka amazonka-core amazonka-ec2 amazonka-elb amazonka-route53;
+    };
+    pkg1 = with builtins; trace ''
+      ----- pkg1: ${pkg0.postFixup}
+    '' pkg0;
+    pkg2 = pkgs.haskell.lib.overrideCabal pkg1 (drv: {
+      postFixup = "rm -rf $out/lib $out/nix-support";
+    });
+    pkg3 = with builtins; trace ''
+      ----- pkg3: ${pkg2.postFixup}
+    '' pkg2;
+  in pkg3;

   upcast-ng = let
     ng = pkgs.haskell.lib.overrideCabal (fns.staticHaskellCallPackage ./upcast/ng.nix {
```

which produces this output:

``` console
$ nix-env -f pkgs -iA upcast
trace: ----- pkg1: rm -rf $out/lib $out/nix-support $out/share

trace: ----- pkg3: rm -rf $out/lib $out/nix-support $out/share

replacing old 'upcast-0.1.1.0'
installing 'upcast-0.1.1.0'
```

With this PR, upcast and upcast-ng retain the `/share` directory, which is essential for them to work.

Refs https://github.com/zalora/microgram/commit/d2b3d3ed810f230735b14df226d90cb24f1a3559#commitcomment-15369590
