### PR TITLE
override bundler_HEAD to use a release instead of a random commit

### DIFF
--- a/pkgs/bundler/bundler-head.nix
+++ b/pkgs/bundler/bundler-head.nix
@@ -1,0 +1,14 @@
+{ buildRubyGem, coreutils, fetchgit }:
+
+buildRubyGem {
+  name = "bundler-1.8.9";
+  namePrefix = "";
+  sha256 = "1k4sk4vf0mascqnahdnqymhr86dqj92bddciz5b2p9sv3qzryq57";
+  dontPatchShebangs = true;
+  postInstall = ''
+    find $out -type f -perm -0100 | while read f; do
+      substituteInPlace $f \
+         --replace "/usr/bin/env" "${coreutils}/bin/env"
+    done
+  '';
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -83,6 +83,10 @@ in rec {
 
   ares = fns.staticHaskellCallPackage ./ares {};
 
+  bundler_HEAD = import ./bundler/bundler-head.nix {
+    inherit (pkgs) buildRubyGem coreutils fetchgit;
+  };
+
   couchbase = pkgs.callPackage ./couchbase {};
 
   curl-loader = pkgs.callPackage ./curl-loader {};

--- a/sdk.nix
+++ b/sdk.nix
@@ -38,7 +38,7 @@ rec {
     };
 
     packageOverrides = pkgs: rec {
-      inherit (ugpkgs) erlang imagemagick linux nix;
+      inherit (ugpkgs) bundler_HEAD erlang imagemagick linux nix;
       mysql = ugpkgs.mariadb;
       php = ugpkgs.php54;
       git = pkgs.gitMinimal;


### PR DESCRIPTION
stealing from https://github.com/NixOS/nixpkgs/pull/12787 for now
