### PR TITLE
upcast-ng: rename executable in postFixup

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -360,13 +360,14 @@ in rec {
     postFixup = "rm -rf $out/lib $out/nix-support";
   });
 
-  upcast-ng = let
-    ng = lib.overrideDerivation (fns.staticHaskellCallPackage ./upcast/ng.nix {
-      inherit amazonka amazonka-core amazonka-ec2 amazonka-elb amazonka-route53;
-    }) (drv: {
-      postFixup = "rm -rf $out/lib $out/nix-support";
-    });
-  in pkgs.writeScriptBin "upcast-ng" "${ng}/bin/upcast $*";
+  upcast-ng = lib.overrideDerivation (fns.staticHaskellCallPackage ./upcast/ng.nix {
+    inherit amazonka amazonka-core amazonka-ec2 amazonka-elb amazonka-route53;
+  }) (drv: {
+    postFixup = ''
+      rm -rf $out/lib $out/nix-support
+      mv $out/bin/upcast $out/bin/upcast-ng
+    '';
+  });
 
   vault = pkgs.callPackage ./vault {};
 


### PR DESCRIPTION
Rename upcast-ng's executable in postFixup, so paths relative to it can be resolved (e.g. `${upcast-ng}/nix/eval-infra.nix`).
