### PR TITLE
autohostname: shellcheck and stuff

### DIFF
--- a/nixos/ec2/autohostname.nix
+++ b/nixos/ec2/autohostname.nix
@@ -85,6 +85,7 @@ let
  '';
 
   ec2-autohostname = ''
+    set -efuo pipefail
     ${ip} route delete blackhole 169.254.169.254 2>/dev/null || true
     # registering route 53 hostnames if any:
     echo ${concatStringsSep " " (
@@ -147,7 +148,7 @@ in
 
       script = ''
         while true; do
-          ${pkgs.writeScript "ec2-autohostname" ec2-autohostname}
+          ${sdk.writeBashScript "ec2-autohostname" ec2-autohostname}
           sleep $((120 + $RANDOM % 40))m
         done
       '';


### PR DESCRIPTION
The route53 api call can end up with an error (something like "there is already a pending change for this record"). Adding `-e` makes the service fail and thus it's restarted promptly.
