### PR TITLE
wtf: simplify wtfdb and avoid a jq bug

### DIFF
--- a/wtf/wtf
+++ b/wtf/wtf
@@ -58,7 +58,7 @@ done
 
 checks=$(
   wtfdb \
-      -r -s \
+      -r \
       --arg ytags "${tags[*]}" \
       --arg ntags "${nottags[*]}" \
       --arg names "${alwayschecks[*]}" \
@@ -87,7 +87,7 @@ checks=$(
           enabled_by_name(x) or
           enabled_by_tags(x);
 
-        add | to_entries[] | .value | select(enabled(.)) |
+        to_entries[] | .value | select(enabled(.)) |
           @sh "wtf_wrapper=\(."wtf-wrapper") name=\(.name)"
       '
 )


### PR DESCRIPTION
Because

```
jq --slurp 'add | to_entries[]'
```

is the same as 

```
jq 'to_entries[]'
```

, we can replace the former with the later and conveniently avoid https://github.com/stedolan/jq/issues/1170.

CC @fmap 
